### PR TITLE
Create ProducerConsumer.cs

### DIFF
--- a/ProducerConsumer.cs
+++ b/ProducerConsumer.cs
@@ -25,14 +25,14 @@ class ProducerConsumer {
         // Spawn Producer threads:
         for (int i = 0; i < PRODUCER_THREAD_COUNT; i++) {
             Thread thread = new Thread(() => Producer());
-            thread.Name = $"Thread: {i + 1}";
+            thread.Name = $"Thread-{i + 1}";
             thread.Start();
         }
 
         // Spawn Consumer threads:
         for (int i = 0; i < CONSUMER_THREAD_COUNT; i++) {
             Thread thread = new Thread(() => Consumer());
-            thread.Name = $"Thread: {i + 1}";
+            thread.Name = $"Thread-{i + 1}";
             thread.Start();
         }
         lock (_lock) {
@@ -45,7 +45,7 @@ class ProducerConsumer {
         for(int i = 0; i < itemsToProduce; i++) {
             // Take a lock before accessing the buffer (Queue).
             lock (_lock) {
-                _queue.Enqueue($"{Thread.CurrentThread.Name} + {i + 1}");
+                _queue.Enqueue($"{Thread.CurrentThread.Name}::{i + 1}");
                 Console.WriteLine($"{Thread.CurrentThread.Name} Produced a value {i + 1} | QueueSize: {_queue.Count()}");
 
                 // Signal/Notify all other threads to move from Wait-Queue to Ready-Queue, as we are releasing the lock.
@@ -64,7 +64,7 @@ class ProducerConsumer {
             lock (_lock) {
                 String value;
                 if (_queue.TryDequeue(out value)) {
-                    Console.WriteLine($"{Thread.CurrentThread.Name} consumed a value {value} | QueueSize: {_queue.Count()}");
+                    Console.WriteLine($"{Thread.CurrentThread.Name} consumed a value \"{value}\" | QueueSize: {_queue.Count()}");
                 }
                 else if (_queue.Count == 0) {
                     Console.WriteLine($"{Thread.CurrentThread.Name} could not consume as queue is empty. Trying again in a few moments");

--- a/ProducerConsumer.cs
+++ b/ProducerConsumer.cs
@@ -35,9 +35,6 @@ class ProducerConsumer {
             thread.Name = $"Thread-{i + 1}";
             thread.Start();
         }
-        lock (_lock) {
-            Monitor.PulseAll(_lock);
-        }
     }
 
     /// Method executed by Producer thread.

--- a/ProducerConsumer.cs
+++ b/ProducerConsumer.cs
@@ -1,0 +1,83 @@
+namespace ProducerConsumer;
+
+class ProducerConsumer {
+
+    /// Producer and consumer thread counts, should be 1,1 for the easy case, less race conditions.
+    const int PRODUCER_THREAD_COUNT = 1, CONSUMER_THREAD_COUNT = 1;
+
+    /// Simple buffer for producer and consumer: Shared resource.
+    private static Queue<string> _queue = new Queue<string>();
+
+    /// Lock for accessing the shared resource.
+    private static object _lock = new object();
+
+    /// A few configurable integers so that we can play around with various conditions in concurrency.
+    private static int producerWaitDelay, consumerWaitDelay, itemsToProduce, consumerAttemptsToConsume;
+
+    /// Entry point of dotnet program: Use 'dotnet run'
+    static void Main(string[] args) {
+        /// Configure the various conditions here:
+        producerWaitDelay = 10;
+        consumerWaitDelay = 100;
+        itemsToProduce = 10;
+        consumerAttemptsToConsume = 12;
+
+        // Spawn Producer threads:
+        for (int i = 0; i < PRODUCER_THREAD_COUNT; i++) {
+            Thread thread = new Thread(() => Producer());
+            thread.Name = $"Thread: {i + 1}";
+            thread.Start();
+        }
+
+        // Spawn Consumer threads:
+        for (int i = 0; i < CONSUMER_THREAD_COUNT; i++) {
+            Thread thread = new Thread(() => Consumer());
+            thread.Name = $"Thread: {i + 1}";
+            thread.Start();
+        }
+        lock (_lock) {
+            Monitor.PulseAll(_lock);
+        }
+    }
+
+    /// Method executed by Producer thread.
+    static void Producer() {
+        for(int i = 0; i < itemsToProduce; i++) {
+            // Take a lock before accessing the buffer (Queue).
+            lock (_lock) {
+                _queue.Enqueue($"{Thread.CurrentThread.Name} + {i + 1}");
+                Console.WriteLine($"{Thread.CurrentThread.Name} Produced a value {i + 1} | QueueSize: {_queue.Count()}");
+
+                // Signal/Notify all other threads to move from Wait-Queue to Ready-Queue, as we are releasing the lock.
+                Monitor.PulseAll(_lock);
+                // Wait the current thread which has put a lock for a specific timeout.
+                Monitor.Wait(_lock, producerWaitDelay);
+            }
+        }
+    }
+
+    /// Method executed by Consumer thread.
+    static void Consumer() {
+        int i = 0;
+        while(i++ < consumerAttemptsToConsume) {
+            // Take a lock before accessing the buffer (Queue).
+            lock (_lock) {
+                String value;
+                if (_queue.TryDequeue(out value)) {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} consumed a value {value} | QueueSize: {_queue.Count()}");
+                }
+                else if (_queue.Count == 0) {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} could not consume as queue is empty. Trying again in a few moments");
+                }
+                else {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} could not consume as thread unable to dequeue. Trying again in a few moments");
+                }
+
+                // Signal/Notify all other threads to move from Wait-Queue to Ready-Queue, as we are releasing the lock.
+                Monitor.PulseAll(_lock);
+                // Wait the current thread which has put a lock for a specific timeout.
+                Monitor.Wait(_lock, consumerWaitDelay);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Assumptions:
- Buffer is not capped at some limit. It can store upto `itemsToProduce` no. of items.
- After each produce and consume, the thread will be courteous enough to SignalAndWait for some time so that other threads can consume/produce. [To Avoid Starvation]

Few points:
- Runs instantaneously even though we have added delays in `Monitor.Wait()`, because the `Monitor.PulseAll()` method wakes up the waiting thread to produce/consume.
- Each producer thread produces `itemsToProduce` no. of items concurrently.
- Each consumer thread attempts to consume `consumerAttemptsToConsume` no. of items
- We can customize the number of threads for both producer and consumer.
- `itemsToProduce`, `consumerAttemptsToConsume` and the delays associated with the `Monitor.Wait()` of both consumer and producer can be customized.
 
Sample Output:
<img width="1440" alt="image" src="https://github.com/ujeshmaurya/Concurrency/assets/49209147/2f50fb9c-fd0f-40ad-a4fb-1520a6dd826c">

