### PR TITLE
Producer Consumer dotnet console app

### DIFF
--- a/ProducerConsumer/.vscode/settings.json
+++ b/ProducerConsumer/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "ProducerConsumer.sln"
+}

--- a/ProducerConsumer/ProducerConsumer.csproj
+++ b/ProducerConsumer/ProducerConsumer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/ProducerConsumer/ProducerConsumer.sln
+++ b/ProducerConsumer/ProducerConsumer.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProducerConsumer", "ProducerConsumer.csproj", "{436B2F52-B357-4B76-9A27-EC832EC26768}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{436B2F52-B357-4B76-9A27-EC832EC26768}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{436B2F52-B357-4B76-9A27-EC832EC26768}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{436B2F52-B357-4B76-9A27-EC832EC26768}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{436B2F52-B357-4B76-9A27-EC832EC26768}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DAD3A756-B341-4002-B8CE-6F6D49663C62}
+	EndGlobalSection
+EndGlobal

--- a/ProducerConsumer/Program.cs
+++ b/ProducerConsumer/Program.cs
@@ -1,0 +1,80 @@
+﻿namespace ProducerConsumer;
+
+class ProducerConsumer {
+
+    /// Producer and consumer thread counts, should be 1,1 for the easy case, less race conditions.
+    const int PRODUCER_THREAD_COUNT = 1, CONSUMER_THREAD_COUNT = 1;
+
+    /// Simple buffer for producer and consumer: Shared resource.
+    private static Queue<string> _queue = new Queue<string>();
+
+    /// Lock for accessing the shared resource.
+    private static object _lock = new object();
+
+    /// A few configurable integers so that we can play around with various conditions in concurrency.
+    private static int producerWaitDelay, consumerWaitDelay, itemsToProduce, consumerAttemptsToConsume;
+
+    /// Entry point of dotnet program: Use 'dotnet run'
+    static void Main(string[] args) {
+        /// Configure the various conditions here:
+        producerWaitDelay = 10;
+        consumerWaitDelay = 100;
+        itemsToProduce = 10;
+        consumerAttemptsToConsume = 12;
+
+        // Spawn Producer threads:
+        for (int i = 0; i < PRODUCER_THREAD_COUNT; i++) {
+            Thread thread = new Thread(() => Producer());
+            thread.Name = $"Thread-{i + 1}";
+            thread.Start();
+        }
+
+        // Spawn Consumer threads:
+        for (int i = 0; i < CONSUMER_THREAD_COUNT; i++) {
+            Thread thread = new Thread(() => Consumer());
+            thread.Name = $"Thread-{i + 1}";
+            thread.Start();
+        }
+    }
+
+    /// Method executed by Producer thread.
+    static void Producer() {
+        for(int i = 0; i < itemsToProduce; i++) {
+            // Take a lock before accessing the buffer (Queue).
+            lock (_lock) {
+                _queue.Enqueue($"{Thread.CurrentThread.Name}::{i + 1}");
+                Console.WriteLine($"{Thread.CurrentThread.Name} Produced a value {i + 1} | QueueSize: {_queue.Count()}");
+
+                // Signal/Notify all other threads to move from Wait-Queue to Ready-Queue, as we are releasing the lock.
+                Monitor.PulseAll(_lock);
+                // Wait the current thread which has put a lock for a specific timeout.
+                Monitor.Wait(_lock, producerWaitDelay);
+            }
+        }
+    }
+
+    /// Method executed by Consumer thread.
+    static void Consumer() {
+        int i = 0;
+        while(i++ < consumerAttemptsToConsume) {
+            // Take a lock before accessing the buffer (Queue).
+            lock (_lock) {
+                String value;
+                if (_queue.TryDequeue(out value)) {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} consumed a value \"{value}\" | QueueSize: {_queue.Count()}");
+                }
+                else if (_queue.Count == 0) {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} could not consume as queue is empty. Trying again in a few moments");
+                }
+                else {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} could not consume as thread unable to dequeue. Trying again in a few moments");
+                }
+
+                // Signal/Notify all other threads to move from Wait-Queue to Ready-Queue, as we are releasing the lock.
+                Monitor.PulseAll(_lock);
+                // Wait the current thread which has put a lock for a specific timeout.
+                Monitor.Wait(_lock, consumerWaitDelay);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Run using: dotnet run
Assumptions:
- Buffer is not capped at some limit. It can store upto `itemsToProduce` no. of items.
- After each produce and consume, the thread will be courteous enough to SignalAndWait for some time so that other threads can consume/produce. [To Avoid Starvation]

Few points:
- Runs instantaneously even though we have added delays in `Monitor.Wait()`, because the `Monitor.PulseAll()` method wakes up the waiting thread to produce/consume.
- Each producer thread produces `itemsToProduce` no. of items concurrently.
- Each consumer thread attempts to consume `consumerAttemptsToConsume` no. of items
- We can customize the number of threads for both producer and consumer.
- `itemsToProduce`, `consumerAttemptsToConsume` and the delays associated with the `Monitor.Wait()` of both consumer and producer can be customized.
 
Sample Output:
<img width="1440" alt="image" src="https://github.com/ujeshmaurya/Concurrency/assets/49209147/2f50fb9c-fd0f-40ad-a4fb-1520a6dd826c">

